### PR TITLE
Changing types of crimes.

### DIFF
--- a/src/crawlers/crimes/crimes/items.py
+++ b/src/crawlers/crimes/crimes/items.py
@@ -12,7 +12,7 @@ Crimes Item to be processed, the item must follow the pattern below:
         period: '1/2020',
         monthly_data: [
             { 'nature': 'Latrocínio', 'quantity': 5 },
-            { 'nature': 'Roubo a Transeunte', 'quantity': 7 },
+            { 'nature': 'Roubo a Pedestre', 'quantity': 7 },
             { 'nature': 'Roubo de Veículo', 'quantity': 10 },
             ...
         ]

--- a/src/crawlers/crimes/utils/crimes_nature.py
+++ b/src/crawlers/crimes/utils/crimes_nature.py
@@ -5,11 +5,11 @@ and the values are the names that will be saved in the database.
 
 crimes_nature_df = {
     'LATROCÍNIO': "Latrocínio",
-    'ROUBO A TRANSEUNTE': 'Roubo a Transeunte',
+    'ROUBO A TRANSEUNTE': 'Roubo a Pedestre',
     'ROUBO DE VEÍCULO': 'Roubo de Veículo',
     'ROUBO EM RESIDÊNCIA': 'Roubo de Residência',
     'FURTO EM VEÍCULO': 'Furto de Veículo',
-    'FURTO A TRANSEUNTE': 'Furto a Transeunte',
+    'FURTO A TRANSEUNTE': 'Furto a Pedestre',
     'ESTUPRO': 'Estupro',
 }
 

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -54,12 +54,12 @@
             "type": "string",
             "enum": [
               "Latrocínio",
-              "Roubo a Transeunte",
+              "Roubo a Pedestre",
               "Roubo de Veículo",
               "Roubo de Residência",
               "Estupro",
               "Furto de Veículo",
-              "Furto a Transeunte",
+              "Furto a Pedestre",
               "Outros Roubos",
               "Outros Furtos"
             ],

--- a/src/tests/test_crime.py
+++ b/src/tests/test_crime.py
@@ -60,7 +60,7 @@ class TestCrime(unittest.TestCase):
         Testing get crimes by the crime nature
         """
         result, status = controller.get_all_crimes({ 'secretary': 'df',
-            'nature': 'Roubo a Transeunte' }, None)
+            'nature': 'Roubo a Pedestre' }, None)
 
         self.assertEqual(status, 200)
 
@@ -68,7 +68,7 @@ class TestCrime(unittest.TestCase):
             for city in range(len(result[0]['cities'])):
                 self.assertEqual(
                     result[0]['cities'][city]['crimes'][0]['nature'],
-                    'Roubo a Transeunte')
+                    'Roubo a Pedestre')
 
     def test_get_crimes_by_invalid_crime_nature(self):
         """
@@ -85,7 +85,7 @@ class TestCrime(unittest.TestCase):
         Testing get crimes by an crime nature existing only in another secretary
         """
         result, status = controller.get_all_crimes({ 'secretary': 'sp',
-            'nature': 'Roubo a Transeunte' }, None)
+            'nature': 'Roubo a Pedestre' }, None)
 
         self.assertEqual(status, 400)
         self.assertEqual(result, "Crime não existente na secretaria.")

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -3,12 +3,12 @@ Available crimes of each secretary.
 """
 VALID_CRIMES_DF = [
     'Latrocínio',
-    'Roubo a Transeunte',
+    'Roubo a Pedestre',
     'Roubo de Veículo',
     'Roubo de Residência',
     'Furto de Veículo',
     'Estupro',
-    'Furto a Transeunte',
+    'Furto a Pedestre',
 ]
 
 VALID_CRIMES_SP = [
@@ -30,12 +30,12 @@ ANNUAL_CRIMES_RANGE = [
         'state': 'df',
         'crimes_range': {
             'Latrocínio': [0, 1, 3, 6, 10],
-            'Roubo a Transeunte': [200, 400, 600, 1000, 1500],
+            'Roubo a Pedestre': [200, 400, 600, 1000, 1500],
             'Roubo de Veículo': [0, 10, 20, 50, 100],
             'Roubo de Residência': [0, 5, 10, 20, 50],
             'Furto de Veículo': [50, 100, 200, 500, 700],
             'Estupro': [20, 30, 40, 50, 70],
-            'Furto a Transeunte': [20, 50, 70, 90, 100],
+            'Furto a Pedestre': [20, 50, 70, 90, 100],
         }
     },
     {


### PR DESCRIPTION
Co-authored-by: Brenda <brendasantosv.bs@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Issue
Resolves #45 
<!-- Link the pull request's respective issue -->

## Description
This PR changes the crime types names from "Roubo a Transeunte" and "Furto a Transeunte" to "Roubo a Pedestre" and "Furto a Pedestre".
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## How to validate?
See if the crimes get by the crawlers has the names "Roubo a Pedestre" and "Furto a Pedestre" instead of "Roubo a Transeunte" and "Furto a Transeunte".
<!--- Give tips on how the reviewer of this PR does to validate what was done? (not always obvious) -->
